### PR TITLE
Fix popen call to pdffonts with filename with white spaces

### DIFF
--- a/src/process/OCForMEM.py
+++ b/src/process/OCForMEM.py
@@ -309,7 +309,7 @@ def process(args, file, log, separator, config, image, ocr, locale, web_service,
         if res is False:
             exit(os.EX_IOERR)
         # Check if pdf is already OCR and searchable
-        check_ocr = os.popen('pdffonts ' + file, 'r')
+        check_ocr = os.popen('pdffonts "' + file + '"', 'r')
         tmp = ''
         for line in check_ocr:
             tmp += line


### PR DESCRIPTION
When the file to process contains spaces in its name, the popen call to pdffonts fails (observed in the logs). Just quote the file to prevent this error.