### PR TITLE
Suppression du warning TLS si certPath vide

### DIFF
--- a/src/classes/WebServices.py
+++ b/src/classes/WebServices.py
@@ -18,6 +18,7 @@
 import re
 import json
 import base64
+import urllib3
 import requests
 import holidays
 from requests.auth import HTTPBasicAuth
@@ -30,7 +31,11 @@ class WebServices:
         self.base_url = re.sub(r'(/)+$', '', host)
         self.auth = HTTPBasicAuth(user, pwd)
         self.timeout = int(timeout)
-        self.cert = cert_path
+        if cert_path:
+            self.cert = cert_path
+        else:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+            self.cert = False
         self.check_connection()
 
     def check_connection(self):


### PR DESCRIPTION
# 🔧 Suppression du warning TLS si certPath est vide
## 🎯 Objectif
Empêcher l'affichage du warning `InsecureRequestWarning` dans les logs lorsque l'on utilise une URL HTTPS sans certificat (cas typique en environnement de développement ou de test).

## 📌 Contexte
Actuellement, lorsque certPath est vide (ex : certPath =) dans le fichier `config.ini`, les appels HTTPS vers MEM Courrier passent sans vérification TLS, ce qui déclenche un warning de type :

```shell
InsecureRequestWarning: Unverified HTTPS request is being made to host 'xxxxxx.hellyum.com'. 
Adding certificate verification is strongly advised. 
See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
```

Ce warning est inutile en environnement de test et pollue les logs.

