### PR TITLE
Remove deprecated lib

### DIFF
--- a/scripts/MailCollect/check_folders.py
+++ b/scripts/MailCollect/check_folders.py
@@ -19,7 +19,7 @@
 import sys
 from socket import gaierror
 from imaplib import IMAP4_SSL
-from imap_tools import MailBox, MailBoxUnencrypted
+from imap_tools import MailBox, MailBoxStartTls, MailBoxUnencrypted
 
 hostname = ''
 port = 143
@@ -34,7 +34,7 @@ try:
         conn = MailBox(host=hostname, port=port)
     elif isSTARTTLS:
         print(f'Using STARTTLS encryption on {hostname}:{port}')
-        conn = MailBox(host=hostname, port=port, ssl=True)
+        conn = MailBoxStartTls(host=hostname, port=port)
     else:
         print(f'{hostname}:{port} with no encryption')
         conn = MailBoxUnencrypted(host=hostname, port=port)

--- a/scripts/MailCollect/check_folders.py
+++ b/scripts/MailCollect/check_folders.py
@@ -19,7 +19,7 @@
 import sys
 from socket import gaierror
 from imaplib import IMAP4_SSL
-from imap_tools import MailBox, MailBoxUnencrypted, MailBoxTls
+from imap_tools import MailBox, MailBoxUnencrypted
 
 hostname = ''
 port = 143
@@ -34,7 +34,7 @@ try:
         conn = MailBox(host=hostname, port=port)
     elif isSTARTTLS:
         print(f'Using STARTTLS encryption on {hostname}:{port}')
-        conn = MailBoxTls(host=hostname, port=port)
+        conn = MailBox(host=hostname, port=port, ssl=True)
     else:
         print(f'{hostname}:{port} with no encryption')
         conn = MailBoxUnencrypted(host=hostname, port=port)

--- a/src/classes/Mail.py
+++ b/src/classes/Mail.py
@@ -34,7 +34,7 @@ from socket import gaierror
 from imaplib import IMAP4_SSL
 from tnefparse.tnef import TNEF
 from exchangelib.version import EXCHANGE_O365
-from imap_tools import utils, MailBox, MailBoxTls, MailBoxUnencrypted
+from imap_tools import utils, MailBox, MailBoxUnencrypted
 from exchangelib import Account, OAuth2Credentials, Configuration, OAUTH2, IMPERSONATION, Version, FileAttachment
 
 
@@ -153,7 +153,7 @@ class Mail:
                 if secured_connection == 'SSL':
                     self.conn = MailBox(host=self.host, port=self.port)
                 elif secured_connection == 'STARTTLS':
-                    self.conn = MailBoxTls(host=self.host, port=self.port)
+                    self.conn = MailBox(host=self.host, port=self.port, ssl=True)
                 else:
                     self.conn = MailBoxUnencrypted(host=self.host, port=self.port)
             except (gaierror, SSLError) as _e:

--- a/src/classes/Mail.py
+++ b/src/classes/Mail.py
@@ -34,7 +34,7 @@ from socket import gaierror
 from imaplib import IMAP4_SSL
 from tnefparse.tnef import TNEF
 from exchangelib.version import EXCHANGE_O365
-from imap_tools import utils, MailBox, MailBoxUnencrypted
+from imap_tools import utils, MailBox, MailBoxStartTls, MailBoxUnencrypted
 from exchangelib import Account, OAuth2Credentials, Configuration, OAUTH2, IMPERSONATION, Version, FileAttachment
 
 
@@ -153,7 +153,7 @@ class Mail:
                 if secured_connection == 'SSL':
                     self.conn = MailBox(host=self.host, port=self.port)
                 elif secured_connection == 'STARTTLS':
-                    self.conn = MailBox(host=self.host, port=self.port, ssl=True)
+                    self.conn = MailBoxStartTls(host=self.host, port=self.port)
                 else:
                     self.conn = MailBoxUnencrypted(host=self.host, port=self.port)
             except (gaierror, SSLError) as _e:


### PR DESCRIPTION
L'import du paquet `MailboxTls` provoquait une erreur.

```shell
Traceback (most recent call last):
  File "/opt/edissyum/python-venv/opencaptureformem/bin/kuyruk", line 8, in <module>
    sys.exit(main())
  File "/opt/edissyum/python-venv/opencaptureformem/lib/python3.11/site-packages/kuyruk/__main__.py", line 73, in main
    app = importer.import_object_str(args.app)
  File "/opt/edissyum/python-venv/opencaptureformem/lib/python3.11/site-packages/kuyruk/importer.py", line 37, in import_object_str
    return import_object(module, obj)
  File "/opt/edissyum/python-venv/opencaptureformem/lib/python3.11/site-packages/kuyruk/importer.py", line 28, in import_object
    module = import_module(module_name)
  File "/opt/edissyum/python-venv/opencaptureformem/lib/python3.11/site-packages/kuyruk/importer.py", line 24, in import_module
    return importlib.import_module(name)
  File "/usr/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/opt/edissyum/opencaptureformem/src/main.py", line 39, in <module>
    from src.classes.Mail import move_batch_to_error, send_email_error_pj
  File "/opt/edissyum/opencaptureformem/src/classes/Mail.py", line 35, in <module>
    from imap_tools import utils, MailBox, MailBoxTls, MailBoxUnencrypted
ImportError: cannot import name 'MailBoxTls' from 'imap_tools' (/opt/edissyum/python-venv/opencaptureformem/lib/python3.11/site-packages/imap_tools/__init__.py)
``` 

Corrigé en remplaçant l'usage de `MailboxTls` par `Mailbox` avec l'option `ssl=True`
