### PR TITLE
[fix] check connection with head because if OC follows redirecion (301) it triggers 404 errors. Also it is lighter

### DIFF
--- a/src/classes/WebServices.py
+++ b/src/classes/WebServices.py
@@ -43,7 +43,8 @@ class WebServices:
         Check if remote host is UP
         """
         try:
-            requests.get(self.base_url, timeout=self.timeout, verify=self.cert)
+            # Use HEAD, lighter than get, and not following redirection by default (allow_redirects=False)
+            requests.head(self.base_url, timeout=self.timeout, verify=self.cert)
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
             self.log.error('Error connecting to the host. Exiting program..')
             self.log.error('More information : ' + str(e))


### PR DESCRIPTION
On our on premise installation we notice we have a lot of check calls to our MEM courrier instance:
```bash
172.18.128.141 - - [16/Mar/2026:08:37:39 +0100] "GET /<instance>/rest HTTP/1.1" 301 595 "-" "python-requests/2.32.4"
172.18.128.141 - - [16/Mar/2026:08:37:39 +0100] "GET /<instance>/rest/ HTTP/1.1" 404 2703 "-" "python-requests/2.32.4"
```

Therefore it triggers also a apache error on the 404. The apache mod_dir plugin might be the one that adds the trailing slash, but the route does not exist in the rest API.

I think it is better to use the `HEAD` method to do the check. It is lighter than GET and by default it does not follow redirection. I think that for the purpose of just checking the connection it is ok to use HEAD and it should be sufficient to accept a 301 response to validate the connection is up.